### PR TITLE
Bump highlightjs to version 8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>highlightjs</artifactId>
-    <version>7.3-2-SNAPSHOT</version>
+    <version>8.1-SNAPSHOT</version>
     <name>Highlight.js</name>
     <description>WebJar for Highlight.js</description>
     <url>http://webjars.org</url>
@@ -41,7 +41,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>7.3</upstream.version>
+        <upstream.version>8.0</upstream.version>
         <upstream.url.min>http://yandex.st/highlightjs/${upstream.version}</upstream.url.min>
         <base.dir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</base.dir>
     </properties>
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>2.4.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Bump highlightjs to version 8.0 and maven-release-plugin to 2.4.2
