### PR TITLE
Start adding new requireJS support. However it doesn't work properly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <targetPath>${base.dir}</targetPath>
+            </resource>
+        </resources>
     </build>
 
 </project>

--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -1,0 +1,11 @@
+/*global requirejs */
+
+// Ensure any request for this webjar brings in jQuery.
+requirejs.config({
+    paths: { "highlightjs": webjars.path("highlightjs", "hightlight.min") },
+    shim: { 
+        'highlightjs':  { 
+            'exports': 'hljs'
+        } 
+    }
+});


### PR DESCRIPTION
I'm not quite sure why it doesn't work. The error is

```
GET http://localhost:9000/webjars/highlightjs/8.0/hightlight.min.js 404 (Not Found) 
```

The _hightlightsjs_ jar structure looks as follows

```
resources/
  webjars/
    highlightjs/
       8.0/
          styles/
          highlight.min.js
          webjars-requirejs.js
```
